### PR TITLE
feat: file-based credential storage and settings-driven paths (v0.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-workspace-tools"
-version = "0.3.1"
+version = "0.4.0"
 description = "Google Workspace document export toolkit with CLI and optional AI agent integration"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/google_workspace_tools/__init__.py
+++ b/src/google_workspace_tools/__init__.py
@@ -29,7 +29,7 @@ from .core.exporter import GoogleDriveExporter
 from .core.filters import CalendarEventFilter, GmailSearchFilter
 from .core.types import DocumentConfig, DocumentType, ExportFormat
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 __all__ = [
     "GoogleDriveExporter",

--- a/src/google_workspace_tools/cli/commands/calendar.py
+++ b/src/google_workspace_tools/cli/commands/calendar.py
@@ -16,6 +16,7 @@ from ... import __version__
 from ...core.config import GoogleDriveExporterConfig
 from ...core.exporter import GoogleDriveExporter
 from ...core.filters import CalendarEventFilter
+from ...settings import settings
 from ..formatters import get_formatter
 from ..output import OutputMode, get_output_mode
 from ..schemas import (
@@ -25,7 +26,6 @@ from ..schemas import (
     CalendarOutput,
 )
 from ..utils import cli_error_handler, print_next_steps
-from ...settings import settings
 
 # Create subcommand app
 calendar_app = typer.Typer(

--- a/src/google_workspace_tools/cli/commands/mail.py
+++ b/src/google_workspace_tools/cli/commands/mail.py
@@ -27,8 +27,12 @@ def mail(
     mode: Annotated[str, typer.Option("--mode", "-m", help="Export mode (thread, individual)")] = "thread",
     output: Annotated[Path | None, typer.Option("--output", "-o", help="Output directory (default: stdout)")] = None,
     depth: Annotated[int, typer.Option("--depth", "-d", help="Link following depth")] = 0,
-    credentials: Annotated[Path, typer.Option("--credentials", "-c", help="Path to credentials file")] = settings.credentials_path,
-    token: Annotated[Path, typer.Option("--token", "-t", help="Path to token file")] = settings.token_path,
+    credentials: Annotated[
+        Path, typer.Option("--credentials", "-c", help="Path to credentials file")
+    ] = settings.credentials_path,
+    token: Annotated[
+        Path, typer.Option("--token", "-t", help="Path to token file")
+    ] = settings.token_path,
 ) -> None:
     """Export Gmail messages to JSON or Markdown.
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -63,7 +63,7 @@ class TestVersionCommand:
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert "google-workspace-tools" in result.stdout
-        assert "0.3.1" in result.stdout
+        assert "0.4.0" in result.stdout
 
     def test_version_flag(self):
         """Test --version flag."""

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-tools"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- **Pin `html-to-markdown<3.0`** to avoid breaking API changes (3.x removed `convert_to_markdown()` and `convert_with_inline_images()`)
- **File-based credential import** now works — `FileCredentialStorage.save_client_credentials()` writes to `~/.config/gwt/client_secret.json` instead of being a no-op; `_handle_import()` falls back to file storage when keyring/1password are unavailable (e.g. SSH sessions)
- **All credential/token paths use `settings`** — CLI commands, config defaults, and utils now read from `~/.config/gwt/config.toml` instead of hardcoded CWD-relative paths. Adds `model_validator` to expand `~` in path fields.
- **Bump version to 0.4.0**

## Motivation

macOS Keychain is unavailable over SSH (`errSecInteractionNotAllowed`). File-based storage with stable paths under `~/.config/gwt/` enables `gwt` to work reliably from any directory in SSH sessions.

## Test plan

- [x] All 229 tests pass (unit + e2e)
- [ ] `gwt credentials import -c <file> --storage file` saves to `~/.config/gwt/client_secret.json`
- [ ] `gwt credentials status` shows correct paths and login state
- [ ] `gwt credentials login --storage file` works over SSH