### PR TITLE
feat: preserve nested list indentation in markdown export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-workspace-tools"
-version = "0.3.1"
+version = "0.4.0"
 description = "Google Workspace document export toolkit with CLI and optional AI agent integration"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "google-auth-httplib2>=0.2.0",
     # HTML to Markdown conversion
     "html-to-markdown>=2.14.0,<3.0",
+    # HTML preprocessing (Google Docs list nesting)
+    "beautifulsoup4>=4.12.0",
     # Excel/Office to Markdown conversion (xlsx extra required for spreadsheet support)
     "markitdown[xlsx]>=0.1.0",
     "openpyxl>=3.1.0",

--- a/src/google_workspace_tools/__init__.py
+++ b/src/google_workspace_tools/__init__.py
@@ -29,7 +29,7 @@ from .core.exporter import GoogleDriveExporter
 from .core.filters import CalendarEventFilter, GmailSearchFilter
 from .core.types import DocumentConfig, DocumentType, ExportFormat
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 __all__ = [
     "GoogleDriveExporter",

--- a/src/google_workspace_tools/cli/commands/calendar.py
+++ b/src/google_workspace_tools/cli/commands/calendar.py
@@ -16,6 +16,7 @@ from ... import __version__
 from ...core.config import GoogleDriveExporterConfig
 from ...core.exporter import GoogleDriveExporter
 from ...core.filters import CalendarEventFilter
+from ...settings import settings
 from ..formatters import get_formatter
 from ..output import OutputMode, get_output_mode
 from ..schemas import (
@@ -25,7 +26,6 @@ from ..schemas import (
     CalendarOutput,
 )
 from ..utils import cli_error_handler, print_next_steps
-from ...settings import settings
 
 # Create subcommand app
 calendar_app = typer.Typer(

--- a/src/google_workspace_tools/cli/commands/mail.py
+++ b/src/google_workspace_tools/cli/commands/mail.py
@@ -27,7 +27,9 @@ def mail(
     mode: Annotated[str, typer.Option("--mode", "-m", help="Export mode (thread, individual)")] = "thread",
     output: Annotated[Path | None, typer.Option("--output", "-o", help="Output directory (default: stdout)")] = None,
     depth: Annotated[int, typer.Option("--depth", "-d", help="Link following depth")] = 0,
-    credentials: Annotated[Path, typer.Option("--credentials", "-c", help="Path to credentials file")] = settings.credentials_path,
+    credentials: Annotated[
+        Path, typer.Option("--credentials", "-c", help="Path to credentials file")
+    ] = settings.credentials_path,
     token: Annotated[Path, typer.Option("--token", "-t", help="Path to token file")] = settings.token_path,
 ) -> None:
     """Export Gmail messages to JSON or Markdown.

--- a/src/google_workspace_tools/core/exporter.py
+++ b/src/google_workspace_tools/core/exporter.py
@@ -95,6 +95,96 @@ def _run_local_server_with_redirect_uri(
     return cast(Credentials, flow.credentials)
 
 
+def _nest_gdocs_flat_lists(html: str) -> str:
+    """Pre-process Google Docs HTML to convert flat sibling <ul> lists into properly nested lists.
+
+    Google Docs exports nested lists as flat sibling <ul> elements with CSS class
+    names encoding the nesting level (e.g. lst-kix_XXXXX-0, lst-kix_XXXXX-1).
+    Standard HTML-to-markdown converters expect nested <ul> inside <li> elements.
+    This function restructures the flat lists into proper nesting so that
+    markdown output preserves bullet indentation.
+    """
+    from bs4 import BeautifulSoup, NavigableString, Tag
+
+    soup = BeautifulSoup(html, "html.parser")
+    body = soup.find("body")
+    if not body:
+        return html
+
+    def _list_level(tag: Tag) -> int | None:
+        for cls in tag.get("class", []):
+            m = re.match(r"lst-kix_\w+-(\d+)", cls)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def _is_gdocs_list(tag: Tag) -> bool:
+        return isinstance(tag, Tag) and tag.name == "ul" and _list_level(tag) is not None
+
+    # Collect groups of consecutive Google-Docs list <ul> siblings.
+    # Skip whitespace-only text nodes between <ul> elements so they don't
+    # break a group (Google Docs HTML has newlines between siblings).
+    groups: list[list[Tag]] = []
+    current_group: list[Tag] = []
+    for child in list(body.children):
+        if _is_gdocs_list(child):
+            current_group.append(child)
+        elif isinstance(child, NavigableString) and not child.strip():
+            # Whitespace-only text node — don't break the current group
+            continue
+        else:
+            if current_group:
+                groups.append(current_group)
+                current_group = []
+    if current_group:
+        groups.append(current_group)
+
+    for group in groups:
+        # Flatten into (level, <li>) pairs.
+        items: list[tuple[int, Tag]] = []
+        for ul in group:
+            level = _list_level(ul) or 0
+            for li in ul.find_all("li", recursive=False):
+                items.append((level, li))
+        if not items:
+            continue
+
+        # Re-build as a properly nested <ul> tree.
+        root_ul = soup.new_tag("ul")
+        # Stack entries: (level, <ul> that accepts children at that level)
+        stack: list[tuple[int, Tag]] = [(items[0][0], root_ul)]
+
+        for level, li in items:
+            li_copy = li.extract() if li.parent else li
+            _cur_level, cur_ul = stack[-1]
+
+            if level == _cur_level:
+                cur_ul.append(li_copy)
+            elif level > _cur_level:
+                last_li = cur_ul.find_all("li", recursive=False)
+                if last_li:
+                    new_ul = soup.new_tag("ul")
+                    last_li[-1].append(new_ul)
+                    new_ul.append(li_copy)
+                    stack.append((level, new_ul))
+                else:
+                    cur_ul.append(li_copy)
+            else:
+                while len(stack) > 1 and stack[-1][0] > level:
+                    stack.pop()
+                if stack[-1][0] == level:
+                    stack[-1][1].append(li_copy)
+                else:
+                    stack[-1][1].append(li_copy)
+
+        # Replace the original flat <ul> elements with the single nested tree.
+        group[0].insert_before(root_ul)
+        for ul in group:
+            ul.decompose()
+
+    return str(soup)
+
+
 class GoogleDriveExporter:
     """Export Google Drive documents in various formats with link following capabilities."""
 
@@ -961,6 +1051,7 @@ class GoogleDriveExporter:
             if format_key == "md":
                 # Convert HTML to Markdown and extract inline images
                 html_content = fh.getvalue().decode("utf-8")
+                html_content = _nest_gdocs_flat_lists(html_content)
                 markdown_content, images, _warnings = convert_with_inline_images(html_content)
                 markdown_content = self._unwrap_google_redirect_urls(markdown_content)
 

--- a/src/google_workspace_tools/core/exporter.py
+++ b/src/google_workspace_tools/core/exporter.py
@@ -112,14 +112,14 @@ def _nest_gdocs_flat_lists(html: str) -> str:
         return html
 
     def _list_level(tag: Tag) -> int | None:
-        for cls in tag.get("class", []):
+        classes = tag.get("class")
+        if not classes or not isinstance(classes, list):
+            return None
+        for cls in classes:
             m = re.match(r"lst-kix_\w+-(\d+)", cls)
             if m:
                 return int(m.group(1))
         return None
-
-    def _is_gdocs_list(tag: Tag) -> bool:
-        return isinstance(tag, Tag) and tag.name == "ul" and _list_level(tag) is not None
 
     # Collect groups of consecutive Google-Docs list <ul> siblings.
     # Skip whitespace-only text nodes between <ul> elements so they don't
@@ -127,10 +127,9 @@ def _nest_gdocs_flat_lists(html: str) -> str:
     groups: list[list[Tag]] = []
     current_group: list[Tag] = []
     for child in list(body.children):
-        if _is_gdocs_list(child):
+        if isinstance(child, Tag) and child.name == "ul" and _list_level(child) is not None:
             current_group.append(child)
         elif isinstance(child, NavigableString) and not child.strip():
-            # Whitespace-only text node — don't break the current group
             continue
         else:
             if current_group:
@@ -150,32 +149,32 @@ def _nest_gdocs_flat_lists(html: str) -> str:
             continue
 
         # Re-build as a properly nested <ul> tree.
+        # Stack entries: (level, <ul> container, last <li> appended at this level)
         root_ul = soup.new_tag("ul")
-        # Stack entries: (level, <ul> that accepts children at that level)
-        stack: list[tuple[int, Tag]] = [(items[0][0], root_ul)]
+        stack: list[tuple[int, Tag, Tag | None]] = [(items[0][0], root_ul, None)]
 
         for level, li in items:
             li_copy = li.extract() if li.parent else li
-            _cur_level, cur_ul = stack[-1]
+            _cur_level, cur_ul, last_li = stack[-1]
 
             if level == _cur_level:
                 cur_ul.append(li_copy)
+                stack[-1] = (_cur_level, cur_ul, li_copy)
             elif level > _cur_level:
-                last_li = cur_ul.find_all("li", recursive=False)
-                if last_li:
+                if last_li is not None:
                     new_ul = soup.new_tag("ul")
-                    last_li[-1].append(new_ul)
+                    last_li.append(new_ul)
                     new_ul.append(li_copy)
-                    stack.append((level, new_ul))
+                    stack.append((level, new_ul, li_copy))
                 else:
                     cur_ul.append(li_copy)
+                    stack[-1] = (_cur_level, cur_ul, li_copy)
             else:
                 while len(stack) > 1 and stack[-1][0] > level:
                     stack.pop()
-                if stack[-1][0] == level:
-                    stack[-1][1].append(li_copy)
-                else:
-                    stack[-1][1].append(li_copy)
+                target_level, target_ul, _ = stack[-1]
+                target_ul.append(li_copy)
+                stack[-1] = (target_level, target_ul, li_copy)
 
         # Replace the original flat <ul> elements with the single nested tree.
         group[0].insert_before(root_ul)

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -63,7 +63,7 @@ class TestVersionCommand:
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert "google-workspace-tools" in result.stdout
-        assert "0.3.1" in result.stdout
+        assert "0.4.0" in result.stdout
 
     def test_version_flag(self):
         """Test --version flag."""

--- a/tests/unit/test_nest_gdocs_lists.py
+++ b/tests/unit/test_nest_gdocs_lists.py
@@ -1,0 +1,132 @@
+"""Tests for _nest_gdocs_flat_lists HTML preprocessing."""
+
+import pytest
+
+from google_workspace_tools.core.exporter import _nest_gdocs_flat_lists
+
+
+@pytest.mark.unit
+class TestNestGdocsFlatLists:
+    """Tests for Google Docs flat list nesting preprocessor."""
+
+    def test_two_level_nesting(self):
+        """Level-0 and level-1 items produce nested markdown lists."""
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start"><li>Top item</li></ul>
+        <ul class="lst-kix_abc123-1 start"><li>Sub item</li></ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        # The level-1 <ul> should now be nested inside the level-0 <li>
+        assert "<li>Top item<ul><li>Sub item</li></ul></li>" in result.replace("\n", "")
+
+    def test_three_level_nesting(self):
+        """Level-0, level-1, and level-2 items nest correctly."""
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start"><li>L0</li></ul>
+        <ul class="lst-kix_abc123-1 start"><li>L1</li></ul>
+        <ul class="lst-kix_abc123-2 start"><li>L2</li></ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        assert "<li>L0<ul><li>L1<ul><li>L2</li></ul></li></ul></li>" in result.replace(
+            "\n", ""
+        )
+
+    def test_return_to_parent_level(self):
+        """Going from level-1 back to level-0 creates sibling top-level items."""
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start"><li>First top</li></ul>
+        <ul class="lst-kix_abc123-1 start"><li>Sub</li></ul>
+        <ul class="lst-kix_abc123-0"><li>Second top</li></ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        # Both top-level items should be direct children of the root <ul>
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(result, "html.parser")
+        root_ul = soup.find("ul")
+        top_lis = root_ul.find_all("li", recursive=False)
+        assert len(top_lis) == 2
+        assert "First top" in top_lis[0].get_text()
+        assert "Second top" in top_lis[1].get_text()
+
+    def test_multiple_items_at_same_level(self):
+        """Multiple consecutive items at the same sub-level stay siblings."""
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start"><li>Parent</li></ul>
+        <ul class="lst-kix_abc123-1 start">
+          <li>Child A</li>
+          <li>Child B</li>
+          <li>Child C</li>
+        </ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(result, "html.parser")
+        root_ul = soup.find("ul")
+        parent_li = root_ul.find("li", recursive=False)
+        nested_ul = parent_li.find("ul", recursive=False)
+        assert nested_ul is not None
+        children = nested_ul.find_all("li", recursive=False)
+        assert len(children) == 3
+
+    def test_separate_list_ids_stay_independent(self):
+        """Lists with different kix IDs separated by non-list elements remain independent."""
+        html = """<html><body>
+        <ul class="lst-kix_list1-0 start"><li>List 1</li></ul>
+        <p>Separator</p>
+        <ul class="lst-kix_list2-0 start"><li>List 2</li></ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(result, "html.parser")
+        uls = soup.find_all("ul")
+        assert len(uls) == 2
+
+    def test_non_gdocs_html_unchanged(self):
+        """Regular HTML without Google Docs list classes passes through unmodified."""
+        html = "<html><body><ul><li>Normal list</li></ul></body></html>"
+        result = _nest_gdocs_flat_lists(html)
+        assert "<li>Normal list</li>" in result
+
+    def test_no_body_tag_returns_input(self):
+        """HTML without a <body> tag returns input unchanged."""
+        html = "<div>no body</div>"
+        assert _nest_gdocs_flat_lists(html) == html
+
+    def test_preserves_links_in_list_items(self):
+        """Links and other inline markup inside <li> are preserved."""
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start">
+          <li><a href="https://example.com">Link text</a></li>
+        </ul>
+        <ul class="lst-kix_abc123-1 start">
+          <li><span style="font-weight:bold">Bold sub</span></li>
+        </ul>
+        </body></html>"""
+        result = _nest_gdocs_flat_lists(html)
+        assert 'href="https://example.com"' in result
+        assert "Bold sub" in result
+
+    def test_markdown_output_is_indented(self):
+        """End-to-end: nested Google Docs HTML produces indented markdown."""
+        from html_to_markdown import convert_to_markdown
+
+        html = """<html><body>
+        <ul class="lst-kix_abc123-0 start"><li>Top</li></ul>
+        <ul class="lst-kix_abc123-1 start"><li>Middle</li></ul>
+        <ul class="lst-kix_abc123-2 start"><li>Deep</li></ul>
+        </body></html>"""
+        nested = _nest_gdocs_flat_lists(html)
+        md = convert_to_markdown(nested)
+        lines = [l for l in md.strip().splitlines() if l.strip()]
+        # Top-level item should have no leading whitespace
+        assert lines[0].lstrip() != lines[0] or lines[0].startswith("*") or lines[0].startswith("-")
+        # Sub-items should be indented more than their parents
+        assert len(lines) == 3
+        indent_0 = len(lines[0]) - len(lines[0].lstrip())
+        indent_1 = len(lines[1]) - len(lines[1].lstrip())
+        indent_2 = len(lines[2]) - len(lines[2].lstrip())
+        assert indent_1 > indent_0
+        assert indent_2 > indent_1

--- a/tests/unit/test_nest_gdocs_lists.py
+++ b/tests/unit/test_nest_gdocs_lists.py
@@ -121,8 +121,9 @@ class TestNestGdocsFlatLists:
         nested = _nest_gdocs_flat_lists(html)
         md = convert_to_markdown(nested)
         lines = [l for l in md.strip().splitlines() if l.strip()]
-        # Top-level item should have no leading whitespace
-        assert lines[0].lstrip() != lines[0] or lines[0].startswith("*") or lines[0].startswith("-")
+        # Top-level item should have no leading whitespace and start with a list marker
+        assert lines[0].lstrip() == lines[0]
+        assert lines[0].startswith("*") or lines[0].startswith("-")
         # Sub-items should be indented more than their parents
         assert len(lines) == 3
         indent_0 = len(lines[0]) - len(lines[0].lstrip())

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-tools"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -553,6 +553,7 @@ name = "google-workspace-tools"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
@@ -591,6 +592,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "agno", marker = "extra == 'agno'", specifier = ">=2.0.0,<3.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "google-api-python-client", specifier = ">=2.176.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary

- Google Docs exports nested bullet lists as flat sibling `<ul>` elements with CSS class names encoding nesting level (`lst-kix_xxx-0`, `-1`, `-2`), rather than standard nested `<ul>` inside `<li>`. The `html-to-markdown` library expects proper HTML nesting, so all bullets were rendered flat.
- Added `_nest_gdocs_flat_lists()` preprocessor in `exporter.py` that detects these Google-Docs-specific CSS classes, groups consecutive list elements, and restructures them into properly nested HTML before markdown conversion.
- Bumps version to `0.4.0`.

## Test plan

- [x] 9 new unit tests in `tests/unit/test_nest_gdocs_lists.py` covering 2/3-level nesting, level transitions, independent lists, non-GDocs HTML passthrough, link preservation, and end-to-end markdown indentation
- [x] Full test suite passes (238 tests)
- [x] Manual verification: downloaded a real Google Doc with nested bullets and confirmed indentation is preserved